### PR TITLE
Tuple expected by Django 4.2 for registering admin inlines

### DIFF
--- a/agol_oauth2/admin.py
+++ b/agol_oauth2/admin.py
@@ -13,4 +13,4 @@ admin.site.unregister(User)
 
 @admin.register(User)
 class AGOLUserAdmin(UserAdmin):
-    inlines = RegisteredUserAdmin.inlines + [AGOLUserFieldsInline]
+    inlines = RegisteredUserAdmin.inlines + (AGOLUserFieldsInline,)


### PR DESCRIPTION
Change list to tuple for admin inline. Required for WET Tool update.